### PR TITLE
chore: optimize container workflow to run only on relevant file changes

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -4,6 +4,18 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '*.go'
+      - 'goals/**'
+      - 'scoring/**'
+      - 'db/**'
+      - 'static/**'
+      - 'templates/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Containerfile'
+      - '.dockerignore'
+      - '.github/workflows/container-build.yml'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Add path filters to container-build workflow to skip builds when only
documentation or non-container files are modified. Workflow now triggers
only when Go source, dependencies, static assets, templates, or build
configuration files change.