### PR TITLE
fix: reset game end scores when starting new game

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -689,6 +689,7 @@ async function generateNewGame() {
         const goals = await response.json();
         updateGoalDisplay(goals);
         clearAllCubes();
+        clearAllGameEndScores(true); // Clear game-end scores without confirmation
 
         // Re-fetch goals based on new expansion selection
         await fetchAllGoals();
@@ -1323,8 +1324,8 @@ function getOrdinal(n) {
 }
 
 // Clear all game end scores
-function clearAllGameEndScores() {
-    if (!confirm('Clear all game end scores? This cannot be undone.')) {
+function clearAllGameEndScores(skipConfirm = false) {
+    if (!skipConfirm && !confirm('Clear all game end scores? This cannot be undone.')) {
         return;
     }
 


### PR DESCRIPTION
When clicking 'New Game', the round goals and cube placements were reset, but the Game End scoring form inputs persisted from the previous game.

This fix:
- Adds optional skipConfirm parameter to clearAllGameEndScores()
- Calls clearAllGameEndScores(true) in generateNewGame() to clear game-end scores without showing confirmation dialog
- Preserves confirmation dialog when user manually clicks Clear button

Fixes #35