### PR TITLE
feat: highlight current round end goal

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -381,6 +381,32 @@ header h1 {
     pointer-events: none;
 }
 
+/* Round Highlighting - Current and Completed Rounds */
+.round-row.current-round {
+    background: rgba(91, 154, 160, 0.15);
+    border-left: 4px solid #5B9AA0;
+    border-radius: 8px;
+    padding-left: 16px;
+    box-shadow: 0 0 12px rgba(91, 154, 160, 0.3);
+}
+
+.round-row.current-round .round-number {
+    color: #2C5F6F;
+    font-weight: 800;
+}
+
+.round-row.current-round .goal-info {
+    background: rgba(91, 154, 160, 0.1);
+}
+
+.round-row.completed-round {
+    opacity: 0.6;
+}
+
+.round-row.completed-round .goal-info {
+    background: rgba(0, 0, 0, 0.03);
+}
+
 /* Blue Side Scoring Track */
 .scoring-track {
     position: relative;


### PR DESCRIPTION
Add dynamic highlighting to show which round goal is currently active based on scoring progress:

- Add CSS classes for current-round (golden highlight) and completed-round (reduced opacity)
- Implement getCurrentRound() to determine active round by checking which rounds have all players scored
- Implement updateCurrentRoundHighlight() to apply visual highlighting to round rows
- Integrate highlight updates into cube placement, clearing, and state loading
- Highlights advance automatically when all players score a round

Closes #34