### PR TITLE
feat: add version display on web page

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -102,5 +102,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Containerfile
+++ b/Containerfile
@@ -15,10 +15,14 @@ RUN go mod download
 # Copy source code
 COPY . .
 
+# Version argument (defaults to "dev" if not provided)
+ARG VERSION=dev
+
 # Build the application
 # CGO_ENABLED=0 for static binary
 # -ldflags="-s -w" to reduce binary size
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o wingspan-scoring .
+# -X main.version=${VERSION} to inject version at build time
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.version=${VERSION}" -o wingspan-scoring .
 
 # Stage 2: Create minimal runtime image
 FROM registry.access.redhat.com/ubi10-minimal:10.0

--- a/main.go
+++ b/main.go
@@ -17,6 +17,9 @@ var content embed.FS
 
 var tmpl *template.Template
 
+// version is set at build time via -ldflags
+var version = "dev"
+
 func init() {
 	var err error
 	tmpl, err = template.ParseFS(content, "templates/*.html")
@@ -35,6 +38,7 @@ type PageData struct {
 	PageTitle    string
 	PageSubtitle string
 	CurrentPage  string
+	Version      string
 }
 
 func main() {
@@ -52,6 +56,7 @@ func main() {
 	// Routes
 	http.HandleFunc("/", handleHome)
 	http.HandleFunc("/history", handleHistory)
+	http.HandleFunc("/api/version", handleVersion)
 	http.HandleFunc("/api/new-game", handleNewGame)
 	http.HandleFunc("/api/goals", handleGetGoals)
 	http.HandleFunc("/api/calculate-scores", handleCalculateScores)
@@ -84,6 +89,7 @@ func handleHome(w http.ResponseWriter, r *http.Request) {
 		PageTitle:    "Round Goals",
 		PageSubtitle: "Round End Goals",
 		CurrentPage:  "home",
+		Version:      version,
 	}
 
 	err = tmpl.ExecuteTemplate(w, "index.html", data)
@@ -91,6 +97,13 @@ func handleHome(w http.ResponseWriter, r *http.Request) {
 		log.Println("Error rendering template:", err)
 		http.Error(w, "Error rendering page", http.StatusInternalServerError)
 	}
+}
+
+func handleVersion(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"version": version,
+	})
 }
 
 func handleNewGame(w http.ResponseWriter, r *http.Request) {
@@ -219,6 +232,7 @@ func handleHistory(w http.ResponseWriter, r *http.Request) {
 		PageTitle:    "Game History",
 		PageSubtitle: "Game History",
 		CurrentPage:  "history",
+		Version:      version,
 	}
 
 	err := tmpl.ExecuteTemplate(w, "history.html", data)

--- a/templates/history.html
+++ b/templates/history.html
@@ -84,6 +84,7 @@
         <footer>
             <p>Wingspan board game by Elizabeth Hargrave, published by Stonemaier Games</p>
             <p>This is an unofficial fan-made tool</p>
+            <p class="version">Version: {{.Version}}</p>
         </footer>
     </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -284,6 +284,7 @@
         <footer>
             <p>Wingspan board game by Elizabeth Hargrave, published by Stonemaier Games</p>
             <p>This is an unofficial fan-made tool</p>
+            <p class="version">Version: {{.Version}}</p>
         </footer>
     </div>
 


### PR DESCRIPTION
## Summary
Implements GitHub issue #18 by adding commit SHA display to the web page.

- Added version variable in Go application that can be set at build time via `-ldflags`
- Created `/api/version` endpoint for programmatic access to version info
- Updated both HTML templates to display version in footer
- Modified Containerfile to inject version during build using build arguments
- Updated GitHub Actions workflow to pass commit SHA to container build

## Changes
- [main.go](main.go): Added version variable, updated PageData struct, created `/api/version` endpoint
- [Containerfile](Containerfile): Added VERSION build arg and ldflags injection
- [.github/workflows/container-build.yml](.github/workflows/container-build.yml): Pass commit SHA as build argument
- [templates/index.html](templates/index.html): Display version in footer
- [templates/history.html](templates/history.html): Display version in footer

## How it works
```
GitHub Actions (commit SHA) → Container Build Arg → Go Build Flags → Binary → Web Page
```

## Test Plan
- [x] Build locally without version (defaults to "dev")
- [x] Build locally with version injection
- [x] Verify version appears in HTML footer
- [x] Test `/api/version` endpoint returns correct version
- [ ] Verify version displays in deployed application after merge

Closes #18