### PR TITLE
feat: add git checkout and git stash to allowed commands

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,9 @@
       "Bash(npx:*)",
       "Bash(go test:*)",
       "Bash(go tool cover:*)",
-      "Bash(gh:*)"
+      "Bash(gh:*)",
+      "Bash(git checkout:*)",
+      "Bash(git stash:*)"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
## Summary
Adds `git checkout` and `git stash` commands to the Claude Code allowed bash commands list.

## Changes
- Added `Bash(git checkout:*)` to allow git branch switching
- Added `Bash(git stash:*)` to allow stashing changes

## Rationale
These git commands are safe, read-only or local operations that improve the workflow when switching between branches and managing uncommitted changes. They complement the existing allowed git and gh commands.

## Test Plan
- [x] Commands added to settings.local.json
- [x] Format validated