### PR TITLE
feat: add goal tiles to round end scoring section

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -370,7 +370,7 @@ header h1 {
 .round-row {
     display: grid;
     grid-template-columns: 100px 1fr 450px;
-    gap: 20px;
+    gap: 10px;
     align-items: center;
     padding: 20px 0;
     border-bottom: 2px solid var(--color-goal-card-border);
@@ -394,6 +394,8 @@ header h1 {
 }
 
 .goal-info {
+    display: flex;
+    align-items: center;
     padding: 12px;
     margin-right: 30px;
     cursor: pointer;
@@ -419,6 +421,25 @@ header h1 {
     color: var(--color-goal-card-text);
     line-height: 1.4;
     pointer-events: none;
+}
+
+/* Goal Tile Display */
+.goal-tile-container {
+    width: 80px;
+    height: 80px;
+    flex-shrink: 0;
+    margin-right: 15px;
+}
+
+.goal-tile-container svg {
+    width: 100%;
+    height: 100%;
+    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.15));
+}
+
+.goal-text-container {
+    flex: 1;
+    min-width: 0;
 }
 
 /* Round Highlighting - Current and Completed Rounds */

--- a/static/css/variables.css
+++ b/static/css/variables.css
@@ -124,4 +124,15 @@
   --transition-fast: 150ms ease;
   --transition-base: 250ms ease;
   --transition-slow: 350ms ease;
+
+  /* SVG Sprite Colors for Goal Tiles */
+  --sprite-paper: #f5f1e8;
+  --sprite-corner-color: #8b7355;
+  --sprite-dark-brown: #3d2817;
+  --sprite-taupe: #a89080;
+  --sprite-fish-blue: #4a90a4;
+  --sprite-seed-orange: #d97644;
+  --sprite-fruit-red: #c44569;
+  --sprite-invertebrate-green: #6b9d5f;
+  --sprite-nectar-pink: #e88bb4;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -76,9 +76,16 @@
                 <div class="round-label">
                     <span class="round-number">ROUND 1</span>
                 </div>
-                <div class="goal-info" data-round="1">
-                    <h3 class="goal-name">{{.Goals.Round1.Name}}</h3>
-                    <p class="goal-description">{{.Goals.Round1.Description}}</p>
+                <div class="goal-info" data-round="1" data-goal-id="{{.Goals.Round1.ID}}">
+                    <div class="goal-tile-container">
+                        <svg viewBox="0 0 500 500">
+                            <use class="goal-tile-sprite" href="#placeholder"/>
+                        </svg>
+                    </div>
+                    <div class="goal-text-container">
+                        <h3 class="goal-name">{{.Goals.Round1.Name}}</h3>
+                        <p class="goal-description">{{.Goals.Round1.Description}}</p>
+                    </div>
                 </div>
                 <div class="scoring-track blue-track">
                     <div class="track-label">(1) EACH</div>
@@ -107,9 +114,16 @@
                 <div class="round-label">
                     <span class="round-number">ROUND 2</span>
                 </div>
-                <div class="goal-info" data-round="2">
-                    <h3 class="goal-name">{{.Goals.Round2.Name}}</h3>
-                    <p class="goal-description">{{.Goals.Round2.Description}}</p>
+                <div class="goal-info" data-round="2" data-goal-id="{{.Goals.Round2.ID}}">
+                    <div class="goal-tile-container">
+                        <svg viewBox="0 0 500 500">
+                            <use class="goal-tile-sprite" href="#placeholder"/>
+                        </svg>
+                    </div>
+                    <div class="goal-text-container">
+                        <h3 class="goal-name">{{.Goals.Round2.Name}}</h3>
+                        <p class="goal-description">{{.Goals.Round2.Description}}</p>
+                    </div>
                 </div>
                 <div class="scoring-track blue-track">
                     <div class="track-label">(1) EACH</div>
@@ -138,9 +152,16 @@
                 <div class="round-label">
                     <span class="round-number">ROUND 3</span>
                 </div>
-                <div class="goal-info" data-round="3">
-                    <h3 class="goal-name">{{.Goals.Round3.Name}}</h3>
-                    <p class="goal-description">{{.Goals.Round3.Description}}</p>
+                <div class="goal-info" data-round="3" data-goal-id="{{.Goals.Round3.ID}}">
+                    <div class="goal-tile-container">
+                        <svg viewBox="0 0 500 500">
+                            <use class="goal-tile-sprite" href="#placeholder"/>
+                        </svg>
+                    </div>
+                    <div class="goal-text-container">
+                        <h3 class="goal-name">{{.Goals.Round3.Name}}</h3>
+                        <p class="goal-description">{{.Goals.Round3.Description}}</p>
+                    </div>
                 </div>
                 <div class="scoring-track blue-track">
                     <div class="track-label">(1) EACH</div>
@@ -169,9 +190,16 @@
                 <div class="round-label">
                     <span class="round-number">ROUND 4</span>
                 </div>
-                <div class="goal-info" data-round="4">
-                    <h3 class="goal-name">{{.Goals.Round4.Name}}</h3>
-                    <p class="goal-description">{{.Goals.Round4.Description}}</p>
+                <div class="goal-info" data-round="4" data-goal-id="{{.Goals.Round4.ID}}">
+                    <div class="goal-tile-container">
+                        <svg viewBox="0 0 500 500">
+                            <use class="goal-tile-sprite" href="#placeholder"/>
+                        </svg>
+                    </div>
+                    <div class="goal-text-container">
+                        <h3 class="goal-name">{{.Goals.Round4.Name}}</h3>
+                        <p class="goal-description">{{.Goals.Round4.Description}}</p>
+                    </div>
                 </div>
                 <div class="scoring-track blue-track">
                     <div class="track-label">(1) EACH</div>


### PR DESCRIPTION
## Summary
- Add visual goal tile icons (80x80px) to the left of goal names and descriptions for all four rounds
- Tiles display using the existing SVG sprite sheet and automatically update when goals change
- Reduced grid gap for tighter layout spacing

## Changes Made

### CSS
- Added SVG sprite color variables to `variables.css`
- Implemented goal tile container (80x80px, fixed size with drop shadow)
- Updated `.goal-info` to use flexbox layout with goal tile and text sections
- Reduced `.round-row` grid gap from 20px to 10px for tighter spacing

### HTML
- Added goal tile structure to all 4 rounds with SVG containers
- Added `data-goal-id` attributes to capture backend goal IDs
- Wrapped goal text in `.goal-text-container` for flexible sizing

### JavaScript
- Added `goalIdToSpriteId` mapping object (34 goals: Base, European, Oceania)
- Implemented `loadSpriteSheet()` to fetch and inline SVG sprites on page load
- Implemented `updateGoalTiles()` to dynamically update sprite references
- Fixed sprite references to use local anchors (`#sprite-id`) after inlining
- Updated to use modern `setAttribute()` instead of deprecated XLink namespace
- Integrated tile updates into new game generation and manual goal selection

## Layout
**Before:** Round Number (100px) → Goal Text (flexible) → Scoring Track (450px)  
**After:** Round Number (100px) → Goal Tile (80px) → Goal Text (flexible) → Scoring Track (450px)

## Testing
- ✅ All tests pass
- ✅ Build succeeds
- ✅ Tiles update dynamically when generating new games
- ✅ Tiles update when manually changing goals

🤖 Generated with [Claude Code](https://claude.com/claude-code)