### PR TITLE
fix: update data-goal-id when goals change

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -919,9 +919,13 @@ function setGoalDisplay(goals) {
         if (goal && row) {
             const nameElement = row.querySelector('.goal-name');
             const descElement = row.querySelector('.goal-description');
+            const goalInfoElement = row.querySelector('.goal-info');
 
             if (nameElement) nameElement.textContent = goal.name;
             if (descElement) descElement.textContent = goal.description;
+            if (goalInfoElement && goal.id) {
+                goalInfoElement.setAttribute('data-goal-id', goal.id);
+            }
         }
     });
 }


### PR DESCRIPTION
## Summary
Fix bug where goal tiles showed incorrect sprites after clicking "New Game".

## Problem
The `setGoalDisplay()` function was updating the goal name and description text when new goals were loaded, but it wasn't updating the `data-goal-id` attribute. This caused the sprite mapping to use stale IDs, resulting in tiles that didn't match the displayed goal descriptions.

## Solution
Updated `setGoalDisplay()` function in `static/js/app.js` to also update the `data-goal-id` attribute on the `.goal-info` element whenever goals change.

## Changes
- Added code to update `data-goal-id` attribute in `setGoalDisplay()` function
- Ensures sprite mapping stays synchronized with displayed goal content

## Testing
- ✅ All tests pass
- ✅ Build succeeds  
- ✅ Goal tiles now correctly match descriptions after clicking "New Game"

🤖 Generated with [Claude Code](https://claude.com/claude-code)