### PR TITLE
feat: increase round end goal tile size to 120px

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -425,8 +425,8 @@ header h1 {
 
 /* Goal Tile Display */
 .goal-tile-container {
-    width: 80px;
-    height: 80px;
+    width: 120px;
+    height: 120px;
     flex-shrink: 0;
     margin-right: 15px;
 }


### PR DESCRIPTION
## Summary
- Increases the goal tile display size from 80px to 120px (50% larger)
- Improves visibility and makes the tiles more prominent in the round end scoring section

## Test plan
- [x] Build completes successfully
- [x] Application runs without errors
- [x] Goal tiles display at the new larger size

## Changes
- Updated `.goal-tile-container` width and height in `static/css/styles.css`