### PR TITLE
fix: correct green second place gradient

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -565,11 +565,11 @@ header h1 {
 }
 
 .green-second {
-    background: var(--color-track-green-light) !important;
+    background: var(--color-track-green) !important;
 }
 
 .green-third {
-    background: var(--color-track-green) !important;
+    background: var(--color-track-green-dark) !important;
 }
 
 /* Footer */


### PR DESCRIPTION
## Summary
Fixes the visual regression where second place on the green (competitive) scoring side had no gradient differentiation from first place.

## Changes
Updated CSS in `static/css/styles.css`:
- `.green-second`: Changed from `--color-track-green-light` (#A8BBA8) to `--color-track-green` (#8FA88F)
- `.green-third`: Changed from `--color-track-green` (#8FA88F) to `--color-track-green-dark` (#7A947A)

## Result
Proper visual gradient now displays:
- First place: #A8BBA8 (lightest green)
- Second place: #8FA88F (medium green)
- Third place: #7A947A (darkest green)

Fixes #60