### PR TITLE
fix: correct filled columns description to 3 spaces

### DIFF
--- a/goals/goals.go
+++ b/goals/goals.go
@@ -139,7 +139,7 @@ var EuropeanGoals = []Goal{
 	{
 		ID:          "eu-filled-columns",
 		Name:        "Filled Columns",
-		Description: "Count the number of columns with all 5 spaces filled",
+		Description: "Count the number of columns with all 3 spaces filled",
 		Expansion:   "european",
 	},
 	{


### PR DESCRIPTION
## Summary
Fixes the "Filled Columns" round goal description which incorrectly stated "all 5 spaces filled" when it should say "all 3 spaces filled".

## Changes
- Updated description in `goals/goals.go` line 142 from "5 spaces" to "3 spaces"

## Explanation
In Wingspan, columns are vertical (3 birds tall across 3 habitat rows), not horizontal (5 birds wide). The previous description was misleading players about how to count their filled columns.

## Testing
- All tests pass: `go test ./...`
- Build successful: `go build`

Fixes #56