### PR TITLE
feat: add custom container image build to devfile

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -6,10 +6,19 @@ metadata:
   projectType: Go
 
 components:
+  # Image component to build custom image with additional tools
+  - name: custom-image
+    image:
+      imageName: wingspan-scoring-dev:latest
+      dockerfile:
+        uri: .devcontainer/ContainerFile
+        buildContext: .devcontainer
+      autoBuild: true
+
   # Container component for the development environment
   - name: dev-container
     container:
-      image: registry.redhat.io/devspaces/udi-rhel9:latest
+      image: wingspan-scoring-dev:latest
       memoryLimit: 4Gi
       cpuLimit: 2000m
       mountSources: true


### PR DESCRIPTION
- Add image component to build custom dev container from ContainerFile
- Update dev-container to use custom image instead of base UDI
- Enable autoBuild to rebuild image when ContainerFile changes
- Remove Claude CLI install from ContainerFile (non-functional URL)
- This allows custom tools like gh CLI to be pre-installed in Dev Spaces