### PR TITLE
feat: add game history export functionality

### DIFF
--- a/export/export.go
+++ b/export/export.go
@@ -1,0 +1,81 @@
+package export
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"strconv"
+	"wingspan-scoring/db"
+)
+
+// CSV header matching the import format
+var csvHeader = []string{
+	"GameID",
+	"Date",
+	"IncludeOceania",
+	"PlayerName",
+	"BirdPoints",
+	"BonusCards",
+	"RoundGoals",
+	"Eggs",
+	"CachedFood",
+	"TuckedCards",
+	"NectarForest",
+	"NectarGrassland",
+	"NectarWetland",
+	"UnusedFood",
+	"Total",
+	"Rank",
+}
+
+// ExportGamesToCSV converts game results to CSV format matching the import format.
+// Each player in each game becomes one row in the CSV.
+func ExportGamesToCSV(games []db.GameResult) ([]byte, error) {
+	var buf bytes.Buffer
+	writer := csv.NewWriter(&buf)
+
+	// Write header
+	if err := writer.Write(csvHeader); err != nil {
+		return nil, fmt.Errorf("failed to write CSV header: %w", err)
+	}
+
+	// Write data rows
+	for _, game := range games {
+		gameID := strconv.FormatInt(game.ID, 10)
+		date := game.CreatedAt.Format("2006-01-02")
+		includeOceania := strconv.FormatBool(game.IncludeOceania)
+
+		for _, player := range game.Players {
+			row := []string{
+				gameID,
+				date,
+				includeOceania,
+				player.PlayerName,
+				strconv.Itoa(player.BirdPoints),
+				strconv.Itoa(player.BonusCards),
+				strconv.Itoa(player.RoundGoals),
+				strconv.Itoa(player.Eggs),
+				strconv.Itoa(player.CachedFood),
+				strconv.Itoa(player.TuckedCards),
+				strconv.Itoa(player.NectarForest),
+				strconv.Itoa(player.NectarGrassland),
+				strconv.Itoa(player.NectarWetland),
+				strconv.Itoa(player.UnusedFood),
+				strconv.Itoa(player.Total),
+				strconv.Itoa(player.Rank),
+			}
+
+			if err := writer.Write(row); err != nil {
+				return nil, fmt.Errorf("failed to write CSV row for game %d, player %s: %w",
+					game.ID, player.PlayerName, err)
+			}
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, fmt.Errorf("CSV writer error: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -1,0 +1,278 @@
+package export
+
+import (
+	"encoding/csv"
+	"strings"
+	"testing"
+	"time"
+	"wingspan-scoring/db"
+	"wingspan-scoring/scoring"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportGamesToCSV_EmptyList(t *testing.T) {
+	csvData, err := ExportGamesToCSV([]db.GameResult{})
+	require.NoError(t, err)
+
+	// Should only have header row
+	reader := csv.NewReader(strings.NewReader(string(csvData)))
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+
+	assert.Len(t, records, 1, "Should have only header row")
+	assert.Equal(t, csvHeader, records[0])
+}
+
+func TestExportGamesToCSV_SingleGameMultiplePlayers(t *testing.T) {
+	games := []db.GameResult{
+		{
+			ID:             1,
+			CreatedAt:      time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+			NumPlayers:     2,
+			IncludeOceania: false,
+			WinnerName:     "Alice",
+			WinnerScore:    92,
+			Players: []scoring.PlayerGameEnd{
+				{
+					PlayerName:  "Alice",
+					BirdPoints:  45,
+					BonusCards:  12,
+					RoundGoals:  18,
+					Eggs:        9,
+					CachedFood:  5,
+					TuckedCards: 3,
+					UnusedFood:  2,
+					Total:       92,
+					Rank:        1,
+				},
+				{
+					PlayerName:  "Bob",
+					BirdPoints:  40,
+					BonusCards:  10,
+					RoundGoals:  15,
+					Eggs:        8,
+					CachedFood:  4,
+					TuckedCards: 2,
+					UnusedFood:  1,
+					Total:       79,
+					Rank:        2,
+				},
+			},
+		},
+	}
+
+	csvData, err := ExportGamesToCSV(games)
+	require.NoError(t, err)
+
+	reader := csv.NewReader(strings.NewReader(string(csvData)))
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+
+	// Header + 2 player rows
+	assert.Len(t, records, 3)
+
+	// Check header
+	assert.Equal(t, csvHeader, records[0])
+
+	// Check Alice's row
+	assert.Equal(t, "1", records[1][0])          // GameID
+	assert.Equal(t, "2024-01-15", records[1][1]) // Date
+	assert.Equal(t, "false", records[1][2])      // IncludeOceania
+	assert.Equal(t, "Alice", records[1][3])      // PlayerName
+	assert.Equal(t, "45", records[1][4])         // BirdPoints
+	assert.Equal(t, "12", records[1][5])         // BonusCards
+	assert.Equal(t, "18", records[1][6])         // RoundGoals
+	assert.Equal(t, "9", records[1][7])          // Eggs
+	assert.Equal(t, "5", records[1][8])          // CachedFood
+	assert.Equal(t, "3", records[1][9])          // TuckedCards
+	assert.Equal(t, "0", records[1][10])         // NectarForest
+	assert.Equal(t, "0", records[1][11])         // NectarGrassland
+	assert.Equal(t, "0", records[1][12])         // NectarWetland
+	assert.Equal(t, "2", records[1][13])         // UnusedFood
+	assert.Equal(t, "92", records[1][14])        // Total
+	assert.Equal(t, "1", records[1][15])         // Rank
+
+	// Check Bob's row
+	assert.Equal(t, "1", records[2][0])   // Same GameID
+	assert.Equal(t, "Bob", records[2][3]) // PlayerName
+	assert.Equal(t, "79", records[2][14]) // Total
+	assert.Equal(t, "2", records[2][15])  // Rank
+}
+
+func TestExportGamesToCSV_MultipleGames(t *testing.T) {
+	games := []db.GameResult{
+		{
+			ID:             1,
+			CreatedAt:      time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			NumPlayers:     2,
+			IncludeOceania: false,
+			WinnerName:     "Alice",
+			WinnerScore:    92,
+			Players: []scoring.PlayerGameEnd{
+				{PlayerName: "Alice", Total: 92, Rank: 1},
+				{PlayerName: "Bob", Total: 79, Rank: 2},
+			},
+		},
+		{
+			ID:             2,
+			CreatedAt:      time.Date(2024, 1, 16, 0, 0, 0, 0, time.UTC),
+			NumPlayers:     2,
+			IncludeOceania: false,
+			WinnerName:     "Carol",
+			WinnerScore:    85,
+			Players: []scoring.PlayerGameEnd{
+				{PlayerName: "Carol", Total: 85, Rank: 1},
+				{PlayerName: "Dave", Total: 80, Rank: 2},
+			},
+		},
+	}
+
+	csvData, err := ExportGamesToCSV(games)
+	require.NoError(t, err)
+
+	reader := csv.NewReader(strings.NewReader(string(csvData)))
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+
+	// Header + 2 games * 2 players = 5 rows
+	assert.Len(t, records, 5)
+
+	// Verify game IDs
+	assert.Equal(t, "1", records[1][0])
+	assert.Equal(t, "1", records[2][0])
+	assert.Equal(t, "2", records[3][0])
+	assert.Equal(t, "2", records[4][0])
+
+	// Verify dates
+	assert.Equal(t, "2024-01-15", records[1][1])
+	assert.Equal(t, "2024-01-16", records[3][1])
+}
+
+func TestExportGamesToCSV_WithOceaniaExpansion(t *testing.T) {
+	games := []db.GameResult{
+		{
+			ID:             1,
+			CreatedAt:      time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			NumPlayers:     2,
+			IncludeOceania: true,
+			WinnerName:     "Alice",
+			WinnerScore:    111,
+			Players: []scoring.PlayerGameEnd{
+				{
+					PlayerName:      "Alice",
+					BirdPoints:      50,
+					BonusCards:      15,
+					RoundGoals:      20,
+					Eggs:            10,
+					CachedFood:      6,
+					TuckedCards:     4,
+					NectarForest:    3,
+					NectarGrassland: 2,
+					NectarWetland:   1,
+					UnusedFood:      3,
+					Total:           111,
+					Rank:            1,
+				},
+				{
+					PlayerName:      "Bob",
+					BirdPoints:      48,
+					BonusCards:      12,
+					RoundGoals:      18,
+					Eggs:            9,
+					CachedFood:      5,
+					TuckedCards:     3,
+					NectarForest:    2,
+					NectarGrassland: 3,
+					NectarWetland:   2,
+					UnusedFood:      2,
+					Total:           102,
+					Rank:            2,
+				},
+			},
+			NectarScoring: &scoring.NectarScoring{
+				Forest:    map[string]int{"Alice": 5, "Bob": 2},
+				Grassland: map[string]int{"Alice": 2, "Bob": 5},
+				Wetland:   map[string]int{"Alice": 5, "Bob": 2},
+			},
+		},
+	}
+
+	csvData, err := ExportGamesToCSV(games)
+	require.NoError(t, err)
+
+	reader := csv.NewReader(strings.NewReader(string(csvData)))
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+
+	assert.Len(t, records, 3) // Header + 2 players
+
+	// Check Oceania flag
+	assert.Equal(t, "true", records[1][2])
+	assert.Equal(t, "true", records[2][2])
+
+	// Check Alice's nectar values
+	assert.Equal(t, "3", records[1][10]) // NectarForest
+	assert.Equal(t, "2", records[1][11]) // NectarGrassland
+	assert.Equal(t, "1", records[1][12]) // NectarWetland
+
+	// Check Bob's nectar values
+	assert.Equal(t, "2", records[2][10]) // NectarForest
+	assert.Equal(t, "3", records[2][11]) // NectarGrassland
+	assert.Equal(t, "2", records[2][12]) // NectarWetland
+}
+
+func TestExportGamesToCSV_HeaderMatchesExpectedFormat(t *testing.T) {
+	expectedHeader := []string{
+		"GameID",
+		"Date",
+		"IncludeOceania",
+		"PlayerName",
+		"BirdPoints",
+		"BonusCards",
+		"RoundGoals",
+		"Eggs",
+		"CachedFood",
+		"TuckedCards",
+		"NectarForest",
+		"NectarGrassland",
+		"NectarWetland",
+		"UnusedFood",
+		"Total",
+		"Rank",
+	}
+
+	assert.Equal(t, expectedHeader, csvHeader)
+	assert.Len(t, csvHeader, 16, "CSV should have 16 columns")
+}
+
+func TestExportGamesToCSV_SpecialCharactersInPlayerName(t *testing.T) {
+	games := []db.GameResult{
+		{
+			ID:             1,
+			CreatedAt:      time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			NumPlayers:     1,
+			IncludeOceania: false,
+			WinnerName:     "Alice, Jr.",
+			WinnerScore:    92,
+			Players: []scoring.PlayerGameEnd{
+				{
+					PlayerName: "Alice, Jr.",
+					Total:      92,
+					Rank:       1,
+				},
+			},
+		},
+	}
+
+	csvData, err := ExportGamesToCSV(games)
+	require.NoError(t, err)
+
+	// CSV should properly escape the comma in the name
+	reader := csv.NewReader(strings.NewReader(string(csvData)))
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+
+	assert.Equal(t, "Alice, Jr.", records[1][3])
+}

--- a/import/import.go
+++ b/import/import.go
@@ -14,22 +14,22 @@ import (
 
 // CSVRecord represents a single row in the import CSV
 type CSVRecord struct {
-	GameID           string
-	Date             string
-	IncludeOceania   string
-	PlayerName       string
-	BirdPoints       string
-	BonusCards       string
-	RoundGoals       string
-	Eggs             string
-	CachedFood       string
-	TuckedCards      string
-	NectarForest     string
-	NectarGrassland  string
-	NectarWetland    string
-	UnusedFood       string
-	Total            string
-	Rank             string
+	GameID          string
+	Date            string
+	IncludeOceania  string
+	PlayerName      string
+	BirdPoints      string
+	BonusCards      string
+	RoundGoals      string
+	Eggs            string
+	CachedFood      string
+	TuckedCards     string
+	NectarForest    string
+	NectarGrassland string
+	NectarWetland   string
+	UnusedFood      string
+	Total           string
+	Rank            string
 }
 
 // ImportError represents an error that occurred during import

--- a/static/js/history.js
+++ b/static/js/history.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initializeEventListeners();
     initializePlayerStats();
     initializeImportForm();
+    initializeExportButton();
 });
 
 function initializeEventListeners() {
@@ -612,4 +613,76 @@ function displayImportErrors(errors) {
 
     importErrors.innerHTML = errorHTML;
     importErrors.style.display = 'block';
+}
+
+// Export functionality
+function initializeExportButton() {
+    const exportBtn = document.getElementById('exportGamesBtn');
+    if (exportBtn) {
+        exportBtn.addEventListener('click', exportGames);
+    }
+}
+
+async function exportGames() {
+    const exportBtn = document.getElementById('exportGamesBtn');
+    const importStatus = document.getElementById('importStatus');
+
+    // Disable button while exporting
+    exportBtn.disabled = true;
+    exportBtn.textContent = 'Exporting...';
+
+    // Hide previous status messages
+    importStatus.style.display = 'none';
+
+    try {
+        const response = await fetch('/api/export');
+
+        if (!response.ok) {
+            throw new Error('Failed to export games');
+        }
+
+        // Get the CSV data as a blob
+        const blob = await response.blob();
+
+        // Create a download link and trigger it
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'wingspan-games-export.csv';
+        document.body.appendChild(a);
+        a.click();
+
+        // Cleanup
+        window.URL.revokeObjectURL(url);
+        document.body.removeChild(a);
+
+        showExportSuccess('Games exported successfully!');
+
+    } catch (error) {
+        console.error('Error exporting games:', error);
+        showExportError(`Export failed: ${error.message}`);
+    } finally {
+        // Re-enable button
+        exportBtn.disabled = false;
+        exportBtn.textContent = 'Export All Games';
+    }
+}
+
+function showExportSuccess(message) {
+    const importStatus = document.getElementById('importStatus');
+    importStatus.textContent = message;
+    importStatus.className = 'import-status success';
+    importStatus.style.display = 'block';
+
+    // Auto-hide after 5 seconds
+    setTimeout(() => {
+        importStatus.style.display = 'none';
+    }, 5000);
+}
+
+function showExportError(message) {
+    const importStatus = document.getElementById('importStatus');
+    importStatus.textContent = message;
+    importStatus.className = 'import-status error';
+    importStatus.style.display = 'block';
 }

--- a/templates/history.html
+++ b/templates/history.html
@@ -36,8 +36,11 @@
 
         <div class="import-section">
             <div class="import-header">
-                <h2>Bulk Import Games</h2>
-                <a href="/static/templates/sample-import.csv" download class="btn-link">Download CSV Template</a>
+                <h2>Bulk Import/Export Games</h2>
+                <div class="import-header-actions">
+                    <a href="/static/templates/sample-import.csv" download class="btn-link">Download CSV Template</a>
+                    <button id="exportGamesBtn" class="btn-secondary">Export All Games</button>
+                </div>
             </div>
 
             <div class="import-content">


### PR DESCRIPTION
## Summary
- Add the ability to export all game history as a CSV file from the game history page
- Export format matches existing import format for consistency
- New "Export All Games" button in the Bulk Import/Export section

## Changes
- **New `export` package** (`export/export.go`): Contains `ExportGamesToCSV()` function to convert game results to CSV format
- **New API endpoint** (`GET /api/export`): Returns downloadable CSV file with all game history
- **UI update** (`templates/history.html`): Added "Export All Games" button next to "Download CSV Template" link
- **JavaScript** (`static/js/history.js`): Added `exportGames()` function to trigger CSV download
- **Tests**: Comprehensive unit tests for export package and handler tests in `main_test.go`

## Test plan
- [x] Run `go test ./...` - all tests pass
- [x] Run `go build` - builds successfully
- [ ] Manual test: Navigate to Game History page and click "Export All Games" button
- [ ] Verify exported CSV can be re-imported using the import functionality