### PR TITLE
feat: add round-by-round scores to game history

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -67,7 +67,8 @@ func createTables() error {
 		winner_name TEXT NOT NULL,
 		winner_score INTEGER NOT NULL,
 		players_json TEXT NOT NULL,
-		nectar_json TEXT
+		nectar_json TEXT,
+		round_breakdown_json TEXT
 	);
 
 	CREATE INDEX IF NOT EXISTS idx_created_at ON game_results(created_at DESC);
@@ -75,7 +76,15 @@ func createTables() error {
 	`
 
 	_, err := DB.Exec(schema)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Migration for existing databases (safe to run multiple times)
+	// ALTER TABLE will fail silently if column already exists
+	_, _ = DB.Exec(`ALTER TABLE game_results ADD COLUMN round_breakdown_json TEXT`)
+
+	return nil
 }
 
 // Close closes the database connection

--- a/scoring/scoring.go
+++ b/scoring/scoring.go
@@ -4,21 +4,30 @@ import (
 	"sort"
 )
 
+// RoundGoalBreakdown represents per-round goal scoring
+type RoundGoalBreakdown struct {
+	Round1 int `json:"round1"`
+	Round2 int `json:"round2"`
+	Round3 int `json:"round3"`
+	Round4 int `json:"round4"`
+}
+
 // PlayerGameEnd represents a player's complete end-game score
 type PlayerGameEnd struct {
-	PlayerName      string `json:"playerName"`
-	BirdPoints      int    `json:"birdPoints"`
-	BonusCards      int    `json:"bonusCards"`
-	RoundGoals      int    `json:"roundGoals"`
-	Eggs            int    `json:"eggs"`
-	CachedFood      int    `json:"cachedFood"`
-	TuckedCards     int    `json:"tuckedCards"`
-	NectarForest    int    `json:"nectarForest"`    // Oceania expansion
-	NectarGrassland int    `json:"nectarGrassland"` // Oceania expansion
-	NectarWetland   int    `json:"nectarWetland"`   // Oceania expansion
-	UnusedFood      int    `json:"unusedFood"`      // For tiebreaker
-	Total           int    `json:"total"`
-	Rank            int    `json:"rank"` // 1 = winner, 2 = second, etc.
+	PlayerName          string              `json:"playerName"`
+	BirdPoints          int                 `json:"birdPoints"`
+	BonusCards          int                 `json:"bonusCards"`
+	RoundGoals          int                 `json:"roundGoals"`
+	RoundGoalsBreakdown *RoundGoalBreakdown `json:"roundGoalsBreakdown,omitempty"`
+	Eggs                int                 `json:"eggs"`
+	CachedFood          int                 `json:"cachedFood"`
+	TuckedCards         int                 `json:"tuckedCards"`
+	NectarForest        int                 `json:"nectarForest"`    // Oceania expansion
+	NectarGrassland     int                 `json:"nectarGrassland"` // Oceania expansion
+	NectarWetland       int                 `json:"nectarWetland"`   // Oceania expansion
+	UnusedFood          int                 `json:"unusedFood"`      // For tiebreaker
+	Total               int                 `json:"total"`
+	Rank                int                 `json:"rank"` // 1 = winner, 2 = second, etc.
 }
 
 // NectarScoring represents nectar points awarded per habitat

--- a/static/css/history.css
+++ b/static/css/history.css
@@ -477,6 +477,24 @@
     font-weight: bold;
 }
 
+/* Round Goals Breakdown */
+.details-round-breakdown {
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px solid var(--color-border-light);
+}
+
+.details-round-breakdown h4 {
+    margin-top: 0;
+    margin-bottom: 16px;
+    color: var(--color-text-primary);
+}
+
+.details-round-breakdown table {
+    width: 100%;
+    margin-top: 10px;
+}
+
 /* Nectar Breakdown */
 .details-nectar h4 {
     margin-bottom: 16px;

--- a/static/js/history.js
+++ b/static/js/history.js
@@ -284,6 +284,49 @@ function displayGameDetails(game) {
             </div>
     `;
 
+    // Add round goals breakdown if available
+    if (game.roundBreakdown && Object.keys(game.roundBreakdown).length > 0) {
+        html += `
+            <div class="details-round-breakdown">
+                <h4>Round Goals Breakdown</h4>
+                <table class="details-table">
+                    <thead>
+                        <tr>
+                            <th>Player</th>
+                            <th>Round 1</th>
+                            <th>Round 2</th>
+                            <th>Round 3</th>
+                            <th>Round 4</th>
+                            <th class="total-col">Total</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+        `;
+
+        game.players.forEach(player => {
+            const breakdown = game.roundBreakdown[player.playerName];
+            if (breakdown) {
+                const total = breakdown.round1 + breakdown.round2 + breakdown.round3 + breakdown.round4;
+                html += `
+                    <tr>
+                        <td><strong>${player.playerName}</strong></td>
+                        <td>${breakdown.round1}</td>
+                        <td>${breakdown.round2}</td>
+                        <td>${breakdown.round3}</td>
+                        <td>${breakdown.round4}</td>
+                        <td class="total-col"><strong>${total}</strong></td>
+                    </tr>
+                `;
+            }
+        });
+
+        html += `
+                    </tbody>
+                </table>
+            </div>
+        `;
+    }
+
     // Add nectar breakdown if Oceania is included
     if (game.includeOceania && game.nectarScoring) {
         html += `


### PR DESCRIPTION
## Summary

Implements round goal breakdown tracking showing individual scores for rounds 1-4 in game history details. This provides transparency into how players scored in each round rather than only showing aggregated totals.

Fixes #94

## Changes

### Backend (Go)
- **scoring/scoring.go**: Add `RoundGoalBreakdown` struct with fields for each round
- **scoring/scoring.go**: Add `RoundGoalsBreakdown` field to `PlayerGameEnd` struct
- **db/db.go**: Add `round_breakdown_json` column to database schema with migration for existing databases
- **db/game_results.go**: Update `GameResult` struct with `RoundBreakdown` field
- **db/game_results.go**: Update `SaveGameResult()` to marshal and save round breakdown
- **db/game_results.go**: Update `GetGameResult()` and `GetAllGameResults()` to unmarshal breakdown
- **db/game_results_test.go**: Add TDD tests for breakdown functionality and backward compatibility

### Frontend (JavaScript/CSS)
- **static/js/app.js**: Modify `calculatePlayerRoundGoalScore()` to return breakdown object instead of single integer
- **static/js/app.js**: Update `calculateGameEndScores()` to include `roundGoalsBreakdown` in API payload
- **static/js/history.js**: Add round breakdown table display to game details view
- **static/css/history.css**: Add styles for round breakdown table

## Test Coverage

- ✅ All tests pass (go test ./...)
- ✅ Race detection clean (go test -race ./...)
- ✅ Coverage: scoring package at 100%, db package at 82.4%
- ✅ TDD tests added for breakdown functionality
- ✅ Backward compatibility test ensures old games still work

## Database Migration

Safe ALTER TABLE migration included that:
- Adds `round_breakdown_json` column to existing databases
- Fails silently if column already exists (idempotent)
- Uses nullable column for backward compatibility

## Backward Compatibility

- Old games without breakdown data continue to work
- Uses `omitempty` JSON tags
- Nullable database columns
- Frontend handles missing breakdown gracefully